### PR TITLE
Update rk3568-odroid-m1-npu.dts to improve network speed

### DIFF
--- a/dtb/rk3568-odroid-m1-npu.dts
+++ b/dtb/rk3568-odroid-m1-npu.dts
@@ -5003,7 +5003,7 @@
 		phy-supply = <0x21>;
 		pinctrl-names = "default";
 		pinctrl-0 = <0xc6 0xc7 0xc8 0xc9 0xca>;
-		tx_delay = <0x4f>;
+		tx_delay = <0x35>;
 		rx_delay = <0x2d>;
 		phandle = <0x269>;
 


### PR DESCRIPTION
Including this patch https://lore.kernel.org/all/20250819075522.2238643-1-tobetter@gmail.com/
This resolves my issue https://github.com/vitalijborissow/rk3568-npu-ODROID-M1/issues/1